### PR TITLE
Bugfix - Icon of a bigger machine now properly scales

### DIFF
--- a/BiggerMachines/HarmonyPatches.cs
+++ b/BiggerMachines/HarmonyPatches.cs
@@ -571,7 +571,7 @@ internal static class HarmonyPatches
         }
 
         var itemData = ItemRegistry.GetDataOrErrorItem(__instance.QualifiedItemId);
-        var scale = Math.Min(4f * 16 / itemData.GetTexture().Height, 4f * bigMachineData.Width);
+        var scale = Math.Min(4f * 16 / itemData.GetTexture().Height, 4f * bigMachineData.Width) * scaleSize;
         var sourceRect = new Rectangle(0, 0, bigMachineData.Width * 16, itemData.GetTexture().Height);
         spriteBatch.Draw(itemData.GetTexture(), location + new Vector2(32f, 32f), sourceRect, color * transparency, 0f, new Vector2(sourceRect.Width / 2, sourceRect.Height / 2), scale,
             SpriteEffects.None, layerDepth);


### PR DESCRIPTION
An icon of a bigger machine will now scale correctly when you hover over it in your inventory, when selected on your toolbar and will animate properly when you're trying to place the bigger machine.

Inventory & toolbar example:
The default look of an icon on the toolbar/inventory:
![image](https://github.com/user-attachments/assets/97e1d5c2-7ee1-4755-9b11-da83e2517d25)

Current situation when you hover over the item or selected on the toolbar, only the stack size number is enlarged: 
![image](https://github.com/user-attachments/assets/49346b00-763e-4765-b6a4-ec4cc63c6938)

With this comment, you'll see that the bigger machine texture will now also enlarge a little bit just as much as the stack size:
![image](https://github.com/user-attachments/assets/cb196800-de67-48fd-b4e7-a05c6e6147a8)


